### PR TITLE
Promote 2026.09.04.1114 to stable

### DIFF
--- a/borg-backup-ui.plg
+++ b/borg-backup-ui.plg
@@ -2,7 +2,7 @@
 <!DOCTYPE PLUGIN [
 <!ENTITY name      "borg-backup-ui">
 <!ENTITY author    "Thorsten Steinberg">
-<!ENTITY version   "2026.08.31.0907">
+<!ENTITY version   "2026.09.04.1114">
 <!ENTITY github    "https://raw.githubusercontent.com/borgforge/borg-backup-ui">
 <!ENTITY pluginURL "&github;/main/&name;.plg">
 <!ENTITY bootdir   "/boot/config/plugins/&name;">
@@ -20,6 +20,10 @@
 
 <CHANGES>
 <![CDATA[
+###2026.09.04.1114###
+- Refreshed the complete German and English user manuals for stable 2026.08.31.0907, including Docker restart priorities, current safety workflows, and aligned high-resolution screenshots.
+- Clarified period-based Borg retention in the Job Wizard and manuals, added retention to the flow preview, and now require at least one retention value greater than zero.
+
 ###2026.08.31.0907###
 - Browse and Restore now filters archives by the selected job archive prefix, keeps prefix history for edited jobs, and shows the active archive pattern with a compact history popover in both the archive selection and job editor.
 - Requires Unraid 7.2.0 or newer so managed Borg SSH connections use a compatible OpenSSH runtime.
@@ -27,9 +31,6 @@
 
 ###2026.08.29.2323###
 - Fixed the Unraid dashboard widget so completed backups no longer remain shown as running, Restore proof matches the in-app dashboard counters, and Repos online only subtracts repositories with an explicit cached error state.
-
-###2026.08.29.1712###
-- Resolved symlinked backup source paths before Borg create so visible share paths that point to another directory back up the target contents instead of creating symlink-only archives.
 
 ]]>
 </CHANGES>
@@ -56,7 +57,7 @@ PLUGIN_DIR="/boot/config/plugins/${NAME}"
 PACKAGE_FILE="${PLUGIN_DIR}/${NAME}-${VERSION}.txz"
 PACKAGE_TMP="${PACKAGE_FILE}.tmp"
 PACKAGE_URL="&pkgurl;"
-EXPECTED_MD5="33936dfd2a918313344695b11b12fbdf"
+EXPECTED_MD5="64d521b3fb35314a0c3ed4952167fc6e"
 INSTALLED_MD5_FILE="${PLUGIN_DIR}/.installed-package-md5"
 VENDOR_DIR="${PLUGIN_DIR}/runtime/vendor"
 VENDOR_BUNDLE_DIR="${PLUGIN_DIR}/runtime/vendor-bundles"

--- a/borg_backup_ui.py
+++ b/borg_backup_ui.py
@@ -136,7 +136,7 @@ def _start_bounded_stderr_collector(stream, *, limit: int = 8192):
     return thread, snapshot
 
 
-APP_VERSION = "2026.08.31.0907"
+APP_VERSION = "2026.09.04.1114"
 APP_AUTHOR  = "Thorsten Steinberg"
 APP_CONTACT_EMAIL = "thorsten.steinberg@gmx.de"
 APP_REPOSITORY_URL = "https://github.com/borgforge/borg-backup-ui"

--- a/release-notes/pending/456.md
+++ b/release-notes/pending/456.md
@@ -1,1 +1,0 @@
-- Refreshed the complete German and English user manuals for stable 2026.08.31.0907, including Docker restart priorities, current safety workflows, and aligned high-resolution screenshots.

--- a/release-notes/pending/458.md
+++ b/release-notes/pending/458.md
@@ -1,1 +1,0 @@
-- Clarified period-based Borg retention in the Job Wizard and manuals, added retention to the flow preview, and now require at least one retention value greater than zero.


### PR DESCRIPTION
Promotes the exact tested Borg Backup UI package to the stable channel.

Changes:
- Promotes test-channel version 2026.09.04.1114.
- Reuses the byte-identical tested package (SHA-256: f2d15018b5fac1d6393e88f5123524789f4cf92e180ec58e9022216fd4e6ed42).
- Verifies tested deployable source digest against origin/main.
- Keeps only the newest five stable packages.

Verification:
- Source commit recorded in package provenance: f11c100ffc80139ff9ba507ab07742845c3d6d4d.
- Release artifact preflight passed without rerunning the full source test suite.
