### PR TITLE
fix: preserve system directory permissions during plugin installation (#484)

### DIFF
--- a/docs/maintainer/release-workflow.md
+++ b/docs/maintainer/release-workflow.md
@@ -80,6 +80,15 @@ Build and publish the test package with:
 It does not rerun pytest and does not modify stable release files in the
 feature branch.
 
+For #484, both package builders pass their archive through the same permission
+filter. Only plugin-owned directories and Slackware package metadata retain
+directory entries; shared ancestors such as `/`, `/boot`, `/etc/rc.d` and `/usr`
+are omitted. Payload directories/executables use `0755`, other regular files
+use `0644`, and ownership is `root:root`. Artifact verification rejects shared
+directory entries and unsafe payload modes before publication or promotion.
+This preserves existing host permissions; it does not repair an already affected
+host. Recovery instructions are in user-manual section 13.6 (German and English).
+
 Verify the published snapshot:
 
 ```bash

--- a/docs/user-manual/de/user-manual.md
+++ b/docs/user-manual/de/user-manual.md
@@ -1176,6 +1176,46 @@ Eine fehlgeschlagene Pflichtmigration versetzt die Anwendung in einen eingeschr�
 
 > **Warnung:** Bearbeiten Sie JSON-Dateien nicht ohne vorherige Sicherung. Verwenden Sie für Support ein Support-Paket und das strukturierte Migrationslog.
 
+### 13.6 Verzeichnisrechte nach einer Plugin-Installation verändert (#484)
+
+Ältere Plugin-Pakete konnten bei der Installation oder einem Update die Rechte
+gemeinsamer Systemverzeichnisse verändern. Im bestätigten Test wechselten `/`,
+`/etc`, `/usr`, `/usr/local`, `/usr/local/emhttp` und
+`/usr/local/emhttp/plugins` von `755` auf `775`. Das kann die Anmeldung mit einem
+SSH-Schlüssel verhindern.
+
+Die korrigierten Pakete lassen die vorhandenen Rechte dieser Verzeichnisse
+unverändert. Bereits veränderte Rechte werden bei der Installation des Fixes
+jedoch nicht automatisch repariert.
+
+**Wiederherstellung:** Auf dem getesteten System mit **Unraid 7.4.0 Beta 2** stellte
+ein normaler Neustart die ursprünglichen Rechte wieder her. Borg Backup UI blieb
+dabei installiert und lief nach dem Start. Eine Deinstallation oder manuelle
+Rechtekorrektur war nicht nötig.
+
+1. Erfassen Sie die Rechte mit dem folgenden Befehl und sichern Sie die Ausgabe.
+2. Starten Sie Unraid über die Weboberfläche normal neu.
+3. Erfassen Sie die Rechte erneut und vergleichen Sie sie mit dem Ausgangszustand
+   vor der betroffenen Installation. Prüfen Sie gegebenenfalls auch die
+   SSH-Schlüsselanmeldung.
+
+```bash
+stat -c '%a %U:%G %n' \
+  / /boot /boot/config /boot/config/plugins \
+  /etc /etc/rc.d \
+  /usr /usr/local /usr/local/emhttp /usr/local/emhttp/plugins \
+  /mnt /var
+```
+
+Im getesteten Ausgangszustand hatten die aufgeführten `/boot`-Verzeichnisse `700`,
+`/etc/rc.d` hatte `777` und die übrigen aufgeführten Verzeichnisse `755`; alle
+gehörten `root:root`. Das sind die gemessenen Referenzwerte dieses Systems, keine
+pauschale Vorgabe für andere Versionen oder bewusst angepasste Rechte. Setzen Sie
+daher nicht alle Verzeichnisse auf `755` und verwenden Sie kein rekursives `chmod`.
+Wenn die Rechte nach dem Neustart abweichen, dokumentieren Sie Unraid-Version
+und beide Ausgaben für die weitere Prüfung. Die Wiederherstellung durch Neustart
+ist hier für Unraid 7.4.0 Beta 2 bestätigt.
+
 ## 14. FAQ
 
 ### Muss ich BorgBackup kennen?

--- a/docs/user-manual/en/user-manual.md
+++ b/docs/user-manual/en/user-manual.md
@@ -1174,6 +1174,42 @@ A failed required migration places the application in restricted maintenance mod
 
 > **Warning:** Do not edit JSON files without a backup. Use a support bundle and the structured migration log when requesting support.
 
+### 13.6 Directory Permissions Changed After Plugin Installation (#484)
+
+Older plugin packages could change shared system-directory permissions during
+installation or updates. In the confirmed test, `/`, `/etc`, `/usr`, `/usr/local`,
+`/usr/local/emhttp` and `/usr/local/emhttp/plugins` changed from `755` to `775`.
+This can prevent SSH public-key login.
+
+Corrected packages preserve the existing permissions of these directories.
+Installing the fix does not automatically repair permissions already changed
+by an older package.
+
+**Recovery:** On the tested **Unraid 7.4.0 Beta 2** system, a normal reboot restored
+the original permissions. Borg Backup UI remained installed and was running after
+startup. Uninstalling the plugin or manually changing permissions was unnecessary.
+
+1. Capture permissions with the command below and save the output.
+2. Reboot Unraid normally through its web interface.
+3. Capture permissions again and compare them with the state before the affected
+   installation. Also check SSH public-key login if applicable.
+
+```bash
+stat -c '%a %U:%G %n' \
+  / /boot /boot/config /boot/config/plugins \
+  /etc /etc/rc.d \
+  /usr /usr/local /usr/local/emhttp /usr/local/emhttp/plugins \
+  /mnt /var
+```
+
+In the tested baseline, the listed `/boot` directories had mode `700`, `/etc/rc.d`
+had `777`, and the other listed directories had `755`; all were owned by
+`root:root`. These are observed reference values for that system, not blanket
+requirements for other versions or intentionally customized permissions. Do not
+set every directory to `755` or use recursive `chmod`. If permissions differ after
+reboot, record the Unraid version and both captures for investigation. Reboot
+recovery is confirmed here for Unraid 7.4.0 Beta 2.
+
 ## 14. FAQ
 
 ### Do I Need BorgBackup Experience?

--- a/plugin/build.sh
+++ b/plugin/build.sh
@@ -228,18 +228,8 @@ ${NAME}:
 EOF
 
 # ── .txz bauen ────────────────────────────────────────────────────────────
-cd "${BUILD_DIR}"
-if command -v makepkg &>/dev/null; then
-  makepkg -l y -c y "${PKG_FILE}"
-else
-  tar --create \
-      --xz \
-      --file="${PKG_FILE}" \
-      --owner=root --group=root \
-      --exclude='./.git' \
-      .
-fi
-cd - >/dev/null
+python3 "${SCRIPT_DIR}/release_workflow.py" build-package \
+  --root "${BUILD_DIR}" --package "${PKG_FILE}"
 
 echo "==> Paket: ${PKG_FILE}"
 

--- a/plugin/release_workflow.py
+++ b/plugin/release_workflow.py
@@ -8,6 +8,7 @@ import hashlib
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 import tarfile
@@ -38,6 +39,70 @@ EXPECTED_PACKAGE_MEMBERS = (
     f"usr/local/emhttp/plugins/{NAME}/app-icon.png",
     PROVENANCE_MEMBER,
 )
+
+# Shared ancestors must never be extracted with build-host permissions (#484).
+PACKAGE_OWNED_DIRECTORIES = (
+    f"boot/config/plugins/{NAME}",
+    f"usr/local/emhttp/plugins/{NAME}",
+    "install",  # Slackware package metadata and generated installation hooks.
+)
+PACKAGE_OWNED_FILES = {"etc/rc.d/rc.borg_backup_ui"}
+
+
+def package_owns_path(name: str) -> bool:
+    return name in PACKAGE_OWNED_FILES or any(
+        name == root or name.startswith(root + "/")
+        for root in PACKAGE_OWNED_DIRECTORIES
+    )
+
+
+def verify_package_permissions(members: list[tarfile.TarInfo]) -> None:
+    for member in members:
+        name = member.name.removeprefix("./").rstrip("/")
+        if not package_owns_path(name):
+            raise RuntimeError(f"Package contains a shared or unexpected system path: {member.name}")
+        if member.uid != 0 or member.gid != 0:
+            raise RuntimeError(f"Package member is not owned by root:root: {member.name}")
+        if member.isdir() or member.isfile():
+            expected = 0o755 if member.isdir() or member.mode & 0o111 else 0o644
+            if member.mode != expected:
+                raise RuntimeError(f"Package member has unsafe permissions: {member.name}")
+
+
+def build_package(root: Path, package: Path) -> None:
+    """Keep both builders, but publish only plugin-owned paths and explicit modes."""
+    makepkg = shutil.which("makepkg")
+    if makepkg:
+        subprocess.run([makepkg, "-l", "y", "-c", "y", str(package)], cwd=root, check=True)
+    else:
+        subprocess.run(
+            ["tar", "--create", "--xz", f"--file={package}",
+             "--owner=root", "--group=root", "--exclude=./.git", "."],
+            cwd=root, check=True,
+        )
+
+    # Filter the finished archive, including makepkg-generated install hooks.
+    # Never extract it or chmod live host paths. The temporary archive stays
+    # beside the build output and replaces it only after successful validation.
+    with tempfile.TemporaryDirectory(prefix=".package-permissions-", dir=package.parent) as temp:
+        filtered = Path(temp) / package.name
+        with tarfile.open(package, "r:xz") as source, tarfile.open(filtered, "w:xz") as target:
+            for member in source:
+                name = member.name.removeprefix("./").rstrip("/")
+                if member.isdir() and not package_owns_path(name):
+                    continue
+                member.uid = member.gid = 0
+                member.uname = member.gname = "root"
+                # PAX metadata must not override the normalized ownership.
+                for key in ("uid", "gid", "uname", "gname"):
+                    member.pax_headers.pop(key, None)
+                if member.isdir() or member.isfile():
+                    member.mode = 0o755 if member.isdir() or member.mode & 0o111 else 0o644
+                target.addfile(member, source.extractfile(member) if member.isfile() else None)
+        with tarfile.open(filtered, "r:xz") as archive:
+            verify_package_permissions(archive.getmembers())
+        os.replace(filtered, package)
+
 
 PACKAGE_INSTALL_BEGIN = "<!-- BEGIN borg-backup-ui package installer -->"
 PACKAGE_INSTALL_END = "<!-- END borg-backup-ui package installer -->"
@@ -666,6 +731,7 @@ def prepare_build_tree(
 
 def package_provenance(package: Path) -> dict[str, object]:
     with tarfile.open(package, "r:*") as archive:
+        verify_package_permissions(archive.getmembers())
         members = {member.name.lstrip("./"): member for member in archive.getmembers()}
         missing = [name for name in EXPECTED_PACKAGE_MEMBERS if name not in members]
         if missing:
@@ -843,6 +909,13 @@ def command_rewrite_package_installer(args: argparse.Namespace) -> None:
 def parser() -> argparse.ArgumentParser:
     result = argparse.ArgumentParser()
     subparsers = result.add_subparsers(dest="command", required=True)
+
+    item = subparsers.add_parser("build-package")
+    item.add_argument("--root", required=True)
+    item.add_argument("--package", required=True)
+    item.set_defaults(func=lambda args: build_package(
+        Path(args.root).resolve(), Path(args.package).resolve()
+    ))
 
     item = subparsers.add_parser("source-digest")
     item.add_argument("--repo", default=".")

--- a/release-notes/pending/484.md
+++ b/release-notes/pending/484.md
@@ -1,0 +1,2 @@
+- Fix #484: Plugin installation and updates preserve existing permissions and ownership of shared Unraid system directories.
+- Recovery for permissions changed by an older package: a normal reboot restored the original modes with the plugin still installed on Unraid 7.4.0-beta.2. Verify permissions after reboot; see the user manual, section 13.6. Installing the corrected package does not repair previously changed permissions automatically.

--- a/tests/test_package_permissions.py
+++ b/tests/test_package_permissions.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tarfile
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location("package_workflow", ROOT / "plugin/release_workflow.py")
+workflow = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(workflow)
+
+APP = "boot/config/plugins/borg-backup-ui"
+UI = "usr/local/emhttp/plugins/borg-backup-ui"
+RC = "etc/rc.d/rc.borg_backup_ui"
+# The maintainer's actual Unraid 7.4.0-beta.2 reference, including non-0755 modes.
+SHARED_MODES = {
+    ".": 0o755, "boot": 0o700, "boot/config": 0o700,
+    "boot/config/plugins": 0o700, "etc": 0o755, "etc/rc.d": 0o777,
+    "usr": 0o755, "usr/local": 0o755, "usr/local/emhttp": 0o755,
+    "usr/local/emhttp/plugins": 0o755, "mnt": 0o755, "var": 0o755,
+}
+
+
+def select_builder(tmp_path, monkeypatch, builder):
+    original_which = shutil.which
+    makepkg = None
+    if builder == "makepkg":
+        # Exercise the makepkg route and preserve its generated metadata/hooks.
+        # This fixture is not a replacement for an actual Unraid install test.
+        makepkg = tmp_path / "makepkg"
+        makepkg.write_text(
+            '#!/bin/sh\nset -eu\n'
+            '[ "$1 $2 $3 $4" = "-l y -c y" ]\n'
+            'printf "#!/bin/sh\\nexit 0\\n" > install/doinst.sh\n'
+            'chmod 755 install/doinst.sh\n'
+            'tar --create --xz --owner=123 --group=456 --file="$5" .\n'
+        )
+        makepkg.chmod(0o755)
+    monkeypatch.setattr(workflow.shutil, "which", lambda name: (
+        str(makepkg) if makepkg else None
+    ) if name == "makepkg" else original_which(name))
+
+
+@pytest.mark.parametrize("builder", ["tar", "makepkg"])
+@pytest.mark.parametrize("build_umask", [0o002, 0o022, 0o077])
+def test_package_preserves_existing_host_modes_and_payload(tmp_path, monkeypatch, builder, build_umask):
+    select_builder(tmp_path, monkeypatch, builder)
+    stage = tmp_path / "stage"
+    package = tmp_path / "plugin.txz"
+    old_umask = os.umask(build_umask)
+    try:
+        for path in (APP, UI, "etc/rc.d", "install"):
+            (stage / path).mkdir(parents=True, exist_ok=True)
+        for path in (f"{APP}/config.example", f"{UI}/plugin.page", "install/slack-desc"):
+            (stage / path).write_bytes(b"unchanged payload\n")
+        (stage / RC).write_text("#!/bin/sh\nexit 0\n")
+        (stage / RC).chmod(0o755)
+        (stage / APP / "config-link").symlink_to("config.example")
+        os.link(stage / APP / "config.example", stage / APP / "config-hardlink")
+        workflow.build_package(stage, package)
+    finally:
+        os.umask(old_umask)
+
+    with tarfile.open(package) as archive:
+        members = {m.name.removeprefix("./").rstrip("/"): m for m in archive}
+        assert not set(members) & set(SHARED_MODES)
+        assert all(m.uid == m.gid == 0 for m in members.values())
+        assert members[APP].mode == 0o755
+        assert members[UI].mode == 0o755
+        assert members[f"{APP}/config.example"].mode == 0o644
+        assert members[RC].mode == 0o755
+        assert ("install/doinst.sh" in members) == (builder == "makepkg")
+        if builder == "makepkg":
+            assert archive.extractfile(members["install/doinst.sh"]).read() == b"#!/bin/sh\nexit 0\n"
+
+    host = tmp_path / "host"
+    host.mkdir()
+    for name, mode in SHARED_MODES.items():
+        directory = host / name
+        directory.mkdir(parents=True, exist_ok=True)
+        directory.chmod(mode)
+    # Also check intentional local customizations, not just stock 0755.
+    (host / "usr/local").chmod(0o750)
+    before = {name: (p.stat().st_mode, p.stat().st_uid, p.stat().st_gid)
+              for name in SHARED_MODES for p in [host / name]}
+    subprocess.run(["tar", "--extract", "--xz", "--same-permissions",
+                    f"--file={package}", f"--directory={host}"], check=True)
+    after = {name: (p.stat().st_mode, p.stat().st_uid, p.stat().st_gid)
+             for name in SHARED_MODES for p in [host / name]}
+    assert after == before
+    for path in ("config.example", "config-link", "config-hardlink"):
+        assert (host / APP / path).read_bytes() == b"unchanged payload\n"
+    assert (host / RC).stat().st_mode & 0o777 == 0o755
+    # Verify delivery on a fresh tree as well as preservation on an existing host.
+    fresh = tmp_path / "fresh"
+    fresh.mkdir()
+    subprocess.run(["tar", "-xJpf", str(package), "-C", str(fresh)], check=True)
+    assert (fresh / RC).is_file()
+    assert (fresh / APP / "config-link").read_bytes() == b"unchanged payload\n"
+
+
+@pytest.mark.parametrize("name", [".", "./", "./usr", "etc/rc.d", "boot/config/plugins", "./var"])
+def test_artifact_validation_rejects_shared_directories_even_with_0755(tmp_path, name):
+    package = tmp_path / "bad.txz"
+    with tarfile.open(package, "w:xz") as archive:
+        member = tarfile.TarInfo(name)
+        member.type = tarfile.DIRTYPE
+        member.mode = 0o755
+        archive.addfile(member)
+    with pytest.raises(RuntimeError, match="shared or unexpected system path"):
+        workflow.package_provenance(package)
+
+
+@pytest.mark.parametrize("kind,mode,uid", [(tarfile.DIRTYPE, 0o775, 0),
+                                         (tarfile.REGTYPE, 0o664, 0),
+                                         (tarfile.REGTYPE, 0o4755, 0),
+                                         (tarfile.REGTYPE, 0o644, 1000)])
+def test_artifact_validation_rejects_unsafe_payload_metadata(kind, mode, uid):
+    member = tarfile.TarInfo(APP + "/payload")
+    member.type, member.mode, member.uid = kind, mode, uid
+    with pytest.raises(RuntimeError, match="unsafe permissions|not owned by root"):
+        workflow.verify_package_permissions([member])
+
+
+def test_package_keeps_pax_owner_metadata_from_overriding_root(tmp_path, monkeypatch):
+    package = tmp_path / "plugin.txz"
+    with tarfile.open(package, "w:xz", format=tarfile.PAX_FORMAT) as archive:
+        member = tarfile.TarInfo(APP + "/payload")
+        member.mode = 0o664
+        member.size = 1
+        member.pax_headers = {"uid": "123", "gid": "456", "uname": "builder", "gname": "builder"}
+        archive.addfile(member, io.BytesIO(b"x"))
+    monkeypatch.setattr(workflow.subprocess, "run", lambda *a, **k: None)
+    workflow.build_package(tmp_path, package)
+    with tarfile.open(package) as archive:
+        member = archive.getmembers()[0]
+        assert member.uid == member.gid == 0
+        assert member.uname == member.gname == "root"
+        assert member.mode == 0o644
+
+
+def test_failed_package_filter_does_not_replace_input(tmp_path, monkeypatch):
+    package = tmp_path / "plugin.txz"
+    with tarfile.open(package, "w:xz") as archive:
+        archive.addfile(tarfile.TarInfo("etc/unrelated.conf"))
+    original = package.read_bytes()
+    monkeypatch.setattr(workflow.subprocess, "run", lambda *a, **k: None)
+    with pytest.raises(RuntimeError, match="shared or unexpected system path"):
+        workflow.build_package(tmp_path, package)
+    assert package.read_bytes() == original
+    assert not list(tmp_path.glob(".package-permissions-*"))


### PR DESCRIPTION
## Problem and change

Installing the previous package changed shared Unraid directory permissions from 0755 to 0775, including `/`, `/etc` and `/usr`. The package contained those directories with permissions inherited from the build environment.

Both the tar and makepkg build routes now filter the finished archive before checksums and publication. Only plugin-owned directories and Slackware installation metadata keep directory entries; shared ancestors are omitted. Plugin directories and executable files receive 0755, other regular files 0644, with root:root ownership. Generated install hooks, links and payload contents are preserved. Package verification rejects shared directory entries and unsafe payload metadata before test publication or stable promotion.

German and English recovery instructions record the maintainer's confirmed result on Unraid 7.4.0-beta.2: a normal reboot restored the original permissions with Borg Backup UI still installed and running. The fixed installer preserves current host permissions; it does not apply a blanket chmod or repair prior damage automatically. The additional uninstall/reboot test is not required.

## Validation

- 39 focused packaging/release-workflow tests passed, including 18 new regression cases.
- Real tar extraction preserves the twelve measured Unraid directory modes/owners, including 0700, 0777 and an intentional 0750 customization, under build umasks 0002, 0022 and 0077.
- Tests cover payload contents, executable scripts, symbolic/hard links, fresh destination trees, metadata validation and failed filtering without replacing the original archive.
- The makepkg build route is exercised using a controlled fixture that emits a tar archive and generated install hook. The maintainer has also completed the actual Unraid installation test of the published candidate.
- Final preflight passed once for pushed commit `81fcea023a118c43a570bc661f06d580f5bbda29`: 810 passed, 2 skipped in 169.35 seconds. The two skips require an unavailable local Borg executable; the Node.js UI test ran successfully.
- Test candidate `2026.09.07.0935` published and verified: snapshot `4edc5602ef9f1ff122ff7a56f7bb1bf027429a1c`, MD5 `54de28ec4ec396f651825a9d28559fe0`. Manifest URLs/version, package provenance and the two-file snapshot match.
- The downloaded package has zero shared-directory entries. Real tar extraction of that exact artifact over the twelve recorded Unraid reference paths preserves every mode, owner and group; plugin payload and startup-script permissions are intact.
- **Maintainer acceptance test passed** on Unraid 7.4.0-beta.2: all twelve directory modes and owners/groups remained identical immediately before and after installing version 2026.09.07.0935. Uptime increased from 30 to 32 minutes across the captures (09:40 to 09:42); no reboot masked the installation result. The authenticated application reported the correct version. [Complete evidence in #484](https://github.com/borgforge/borg-backup-ui/issues/484#issuecomment-5567117189). No additional uninstall/reboot test is outstanding.

No stable artifacts are included and no stable release is approved. Application behavior and the frozen #447 work are unchanged. Fixes #484.
